### PR TITLE
Android fixes for latest Embeddinator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -255,3 +255,4 @@ paket-files/
 *.sln.iml
 
 *.xcuserstate
+androidoutput/

--- a/MyWeatherAndroid/app/build.gradle
+++ b/MyWeatherAndroid/app/build.gradle
@@ -10,6 +10,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        jackOptions.enabled true
     }
     buildTypes {
         release {
@@ -19,6 +20,10 @@ android {
     }
     aaptOptions {
         noCompress 'dll'
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 }
 

--- a/MyWeatherAndroid/app/src/main/java/com/refractored/myweatherandroid/MainActivity.java
+++ b/MyWeatherAndroid/app/src/main/java/com/refractored/myweatherandroid/MainActivity.java
@@ -5,7 +5,7 @@ import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.*;
-import weatherandroid_dll.*;
+import weatherandroid.*;
 
 public class MainActivity extends AppCompatActivity {
     Button button;


### PR DESCRIPTION
- Package names improved, `weatherandroid_dll` has dropped the `_dll`
- We now require Java 1.8, so had to set that up for Android Studio
project
- Updated AAR file
- .gitignore for `androidoutput/`

Details about Java 1.8 here:
https://mono.github.io/Embeddinator-4000/getting-started-java-android.html